### PR TITLE
enable passphrase for ssh-privatekey

### DIFF
--- a/src/components/NewConnectionDialog.vue
+++ b/src/components/NewConnectionDialog.vue
@@ -52,6 +52,10 @@
             <FileInput :file.sync='connection.sshOptions.privatekey' placeholder='SSH Private Key'></FileInput>
           </el-tooltip>
         </el-form-item>
+
+        <el-form-item label="Passphrase">
+          <el-input v-model="connection.sshOptions.passphrase" type='password' autocomplete="off"></el-input>
+        </el-form-item>
       </el-form>
 
       <!-- SSL connection form -->

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -40,6 +40,7 @@ export default {
       localPort: null,
       privateKey: sshOptions.privatekey ?
                   fs.readFileSync(sshOptions.privatekey) : '',
+      passphrase: sshOptions.passphrase
     };
 
     const sshConfigRaw = JSON.parse(JSON.stringify(sshConfig));


### PR DESCRIPTION
enable passphrase for ssh-privatekey.
增加私钥密码，以支持带密码的私钥证书连接ssh