### PR TITLE
Change default value sshOptions.username=root

### DIFF
--- a/src/components/NewConnectionDialog.vue
+++ b/src/components/NewConnectionDialog.vue
@@ -141,7 +141,7 @@ export default {
         sshOptions: {
           host: '',
           port: 22,
-          username: '',
+          username: 'root',
           password: '',
           privatekey: '',
           passphrase: '',


### PR DESCRIPTION
In SSH, the general user name root is used more