### PR TITLE
Add feature: You can refer with {HEX} in the custom formatter

### DIFF
--- a/src/components/CustomFormatter.vue
+++ b/src/components/CustomFormatter.vue
@@ -1,13 +1,13 @@
 <template>
-  <el-dialog :title="$t('message.custom_formatter')" :visible.sync="visible" width='60%' append-to-body>
+  <el-dialog :title="$t('message.custom_formatter')" :visible.sync="visible" append-to-body width='60%'>
     <!-- new formatter btn -->
     <el-button size="mini" @click="addDialog=true">+ {{ $t('message.new') }}</el-button>
     <!-- formatter list -->
     <el-table :data='formatters'>
       <el-table-column
+        label="Name"
         prop="name"
-        width="120"
-        label="Name">
+        width="120">
       </el-table-column>
       <el-table-column
         label="Formatter">
@@ -19,16 +19,16 @@
         label="Operation"
         width="90">
         <template slot-scope="scope">
-          <el-button type="text" @click="removeFormatter(scope.$index)" icon="el-icon-delete"></el-button>
-          <el-button type="text" @click="showEditDialog(scope.row)" icon="el-icon-edit-outline"></el-button>
+          <el-button icon="el-icon-delete" type="text" @click="removeFormatter(scope.$index)"></el-button>
+          <el-button icon="el-icon-edit-outline" type="text" @click="showEditDialog(scope.row)"></el-button>
         </template>
       </el-table-column>
     </el-table>
 
     <!-- new formatter dialog -->
-    <el-dialog :visible.sync="addDialog" :close-on-click-modal='false'
-               :title="!editMode ? $t('message.new') : $t('message.edit')" @closed='reset'
-               append-to-body>
+    <el-dialog :close-on-click-modal='false' :title="!editMode ? $t('message.new') : $t('message.edit')"
+               :visible.sync="addDialog" append-to-body
+               @closed='reset'>
       <el-form label-position="top" size="mini">
         <el-form-item label="Name" required>
           <el-input v-model='formatter.name'></el-input>
@@ -67,6 +67,10 @@
                   <tr>
                     <td>[String]</td>
                     <td><el-tag>{VALUE}</el-tag></td>
+                  </tr>
+                  <tr>
+                    <td>[String]</td>
+                    <td><el-tag>{HEX}</el-tag></td>
                   </tr>
                   <tr>
                     <td>[Hash]</td>

--- a/src/components/ViewerCustom.vue
+++ b/src/components/ViewerCustom.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="text-formated-container">
-    <p :title="fullCommand" class="command-preview">{{previewCommand}}</p>
+    <p :title="fullCommand" class="command-preview">{{ previewCommand }}</p>
 
     <div class="collapse-container">
       <el-button class="collapse-btn" type="text" @click="toggleCollapse">{{
@@ -11,8 +11,8 @@
 
     <JsonViewer
       v-if='show'
-      :value="newContent"
-      :expand-depth="previousDeep">
+      :expand-depth="previousDeep"
+      :value="newContent">
     </JsonViewer>
   </div>
 </template>
@@ -68,8 +68,8 @@ export default {
         return false;
       }
 
-      const command = formatter.command;
-      const params = formatter.params;
+      const { command } = formatter;
+      const { params } = formatter;
       const paramsReplaced = this.replaceTemplate(params);
 
       return `${command} ${paramsReplaced}`;
@@ -81,19 +81,15 @@ export default {
 
       const dataMap = this.dataMap ? this.dataMap : {};
       const mapObj = {
-        "{KEY}": this.redisKey,
+        '{KEY}': this.redisKey,
         // "{VALUE}": this.content,
-        "{FIELD}": dataMap.key,
-        "{SCORE}": dataMap.score,
-        "{MEMBER}": dataMap.member,
+        '{FIELD}': dataMap.key,
+        '{SCORE}': dataMap.score,
+        '{MEMBER}': dataMap.member,
       };
 
-      const re = new RegExp(Object.keys(mapObj).join("|"), "gi");
-      const replaced = params.replace(re, matched => {
-        return mapObj[matched];
-      });
-
-      return replaced;
+      const re = new RegExp(Object.keys(mapObj).join('|'), 'gi');
+      return params.replace(re, matched => mapObj[matched]);
     },
     execCommand() {
       if (!this.content || !this.content.length) {
@@ -106,19 +102,22 @@ export default {
         return this.execResult = 'Command Error, Check Config!';
       }
 
-      // in case of long content
-      this.previewCommand = command.replace(
-        "{VALUE}",
-        this.$util.cutString(this.content.toString(), this.previewContentMax)
+      this.fullCommand = command.replace(
+        '{VALUE}',
+        this.content,
+      ).replace(
+        '{HEX}',
+        Buffer.from(this.content).toString('hex'),
       );
-      this.fullCommand = command.replace("{VALUE}", this.content);
+
+      // in case of long content
+      this.previewCommand = this.$util.cutString(this.fullCommand, this.previewContentMax);
 
       try {
         shell.exec(this.fullCommand, (e, stdout, stderr) => {
           if (e || stderr) {
             this.execResult = `${e.message.trim()}\n${stdout.trim()}\n${stderr.trim()}`;
-          }
-          else {
+          } else {
             this.execResult = stdout.trim();
           }
         });
@@ -134,8 +133,8 @@ export default {
 </script>
 
 <style type="text/css">
-  .text-formated-container .command-preview {
-    color: #9798a7;
-    word-break: break-word;
-  }
+.text-formated-container .command-preview {
+  color: #9798a7;
+  word-break: break-word;
+}
 </style>


### PR DESCRIPTION
You can refer with {HEX} in the custom formatter to the content hexadecimal string representation.

That's necessary if you have binary data in the content, because you can't pass a binary data in a string argument...
(like 0x00)