### PR TITLE
Feature support to load all keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 
 ## Feature Log
 
+- 2022-01-05: Support to load all keys
 - 2022-01-01: Brotli\Gzip\Deflate Support && RedisJSON Support
 - 2021-11-26: JSON Editable && Subscribe Support
 - 2021-08-30: Execution log Support && Add Hot Keys

--- a/src/components/FormatViewer.vue
+++ b/src/components/FormatViewer.vue
@@ -75,7 +75,7 @@ export default {
   props: {
     float: {default: 'right'},
     content: {default: () => Buffer.from('')},
-    textrows: {default: 6},
+    textrows: {default: 30},
     disabled: {type: Boolean, default: false},
     redisKey:  {default: () => Buffer.from('')},
     dataMap: {type: Object, default: () => {}},

--- a/src/components/JsonEditor.vue
+++ b/src/components/JsonEditor.vue
@@ -149,7 +149,7 @@ export default {
 
 <style type="text/css">
   .text-formated-container #monaco-editor-con {
-    min-height: 150px;
+    min-height: calc(100vh - 580px);
     max-height: 100vh;
     clear: both;
     overflow: hidden;

--- a/src/components/KeyList.vue
+++ b/src/components/KeyList.vue
@@ -7,15 +7,25 @@
       :client="client"
       :keyList="keyList">
     </component>
+      <!-- load more -->
+      <div class='buttonsWrapper'>
+        <el-button
+          ref='scanMoreBtn'
+          class='load-more-keys'
+          :disabled='scanMoreDisabled'
+          @click='refreshKeyList(false)'>
+          {{ $t('message.load_more_keys') }}
+        </el-button>
 
-    <!-- load more -->
-    <el-button
-      ref='scanMoreBtn'
-      class='load-more-keys'
-      :disabled='scanMoreDisabled'
-      @click='refreshKeyList(false)'>
-      {{ $t('message.load_more_keys') }}
-    </el-button>
+        <!-- load all -->
+        <el-button
+          ref='scanAllBtn'
+          class='load-more-keys'
+          type= 'danger'
+          @click='loadAllKeys()'>
+          {{ $t('message.load_all_keys') }}
+        </el-button>
+      </div>
   </div>
 </template>
 
@@ -27,8 +37,6 @@ export default {
   data() {
     return {
       keyList: [],
-      // keyListType: this.config.separator === '' ? 'KeyListNormal' : 'KeyListTree',
-      // keysPageSize: this.keyListType === 'KeyListNormal' ? 200 : 1000,
       keyListType: 'KeyListTree',
       searchPageSize: 10000,
       scanStreams: [],
@@ -99,15 +107,19 @@ export default {
         }
       }
     },
-    initScanStreamsAndScan() {
-      // this.client.nodes: cluster
+    loadAllKeys(){
+      this.$parent.$parent.$parent.$refs.operateItem.searchIcon = 'el-icon-loading';
+      this.initScanStreamsAndScan(true);
+    },
+    initScanStreamsAndScan(loadAll = false) {
       let nodes = this.client.nodes ? this.client.nodes('master') : [this.client];
       this.scanningCount = nodes.length;
 
+      let keysPageSize = loadAll ? 50000 : this.keysPageSize;
       nodes.map(node => {
         let scanOption = {
           match: this.getMatchMode(),
-          count: this.keysPageSize,
+          count: keysPageSize,
         }
 
         // scan count is bigger when in search mode
@@ -120,7 +132,7 @@ export default {
           this.onePageList = this.onePageList.concat(keys);
 
           // scan once reaches page size
-          if (this.onePageList.length >= this.keysPageSize) {
+          if (this.onePageList.length >= keysPageSize && loadAll === false) {
             // temp stop
             stream.pause();
             // search input icon recover
@@ -269,5 +281,8 @@ export default {
     width: 100%;
     font-size: 75%;
     line-height: 1px;
+  }
+  .buttonsWrapper {
+    display: flex;
   }
 </style>

--- a/src/components/KeyList.vue
+++ b/src/components/KeyList.vue
@@ -22,7 +22,8 @@
           ref='scanAllBtn'
           class='load-more-keys'
           type= 'danger'
-          @click='loadAllKeys()'>
+          @click='loadAllKeys()'
+          v-show='canLoadAllKeys'>
           {{ $t('message.load_all_keys') }}
         </el-button>
       </div>
@@ -53,6 +54,9 @@ export default {
     keysPageSize() {
       let keysPageSize = parseInt(this.globalSettings['keysPageSize']);
       return keysPageSize ? keysPageSize : 500;
+    },
+    canLoadAllKeys(){
+        return this.globalSettings['canLoadAllKeys'];
     },
   },
   created() {

--- a/src/components/Setting.vue
+++ b/src/components/Setting.vue
@@ -46,6 +46,7 @@
             <i slot="reference" class="el-icon-question"></i>
           </el-popover>
         </span>
+        <el-switch v-model='form.canLoadAllKeys'></el-switch> {{ $t('message.can_load_all_keys') }}
       </el-form-item>
 
       <!-- export connections -->
@@ -133,7 +134,7 @@ export default {
   data() {
     return {
       visible: false,
-      form: {fontFamily: '', zoomFactor: 1.0, keysPageSize: 500},
+      form: {fontFamily: '', zoomFactor: 1.0, keysPageSize: 500, canLoadAllKeys: false},
       importConnectionVisible: false,
       connectionFileContent: '',
       appVersion: (new URL(window.location.href)).searchParams.get('version'),

--- a/src/i18n/langs/cn.js
+++ b/src/i18n/langs/cn.js
@@ -145,6 +145,7 @@ const cn = {
     hide_window: '隐藏窗口',
     minimize_window: '最小化窗口',
     maximize_window: '最大化窗口',
+    load_all_keys: '加载所有',
   },
 };
 

--- a/src/i18n/langs/cn.js
+++ b/src/i18n/langs/cn.js
@@ -146,6 +146,7 @@ const cn = {
     minimize_window: '最小化窗口',
     maximize_window: '最大化窗口',
     load_all_keys: '加载所有',
+    can_load_all_keys: '启用按钮以加载所有键',
   },
 };
 

--- a/src/i18n/langs/de.js
+++ b/src/i18n/langs/de.js
@@ -145,6 +145,7 @@ const de = {
     hide_window: 'Fenster ausblenden',
     minimize_window: 'Fenster minimieren',
     maximize_window: 'Fenster maximieren',
+    load_all_keys: 'alle laden',
   },
 };
 

--- a/src/i18n/langs/de.js
+++ b/src/i18n/langs/de.js
@@ -146,6 +146,7 @@ const de = {
     minimize_window: 'Fenster minimieren',
     maximize_window: 'Fenster maximieren',
     load_all_keys: 'alle laden',
+    can_load_all_keys: 'Schaltfläche aktivieren, um alle Schlüssel zu laden',
   },
 };
 

--- a/src/i18n/langs/en.js
+++ b/src/i18n/langs/en.js
@@ -146,6 +146,7 @@ const en = {
     minimize_window: 'Minimize window',
     maximize_window: 'Maximize window',
     load_all_keys: 'load all',
+    can_load_all_keys: 'Enable button to load all keys',
   },
 };
 

--- a/src/i18n/langs/en.js
+++ b/src/i18n/langs/en.js
@@ -145,6 +145,7 @@ const en = {
     hide_window: 'Hide Window',
     minimize_window: 'Minimize window',
     maximize_window: 'Maximize window',
+    load_all_keys: 'load all',
   },
 };
 

--- a/src/i18n/langs/fr.js
+++ b/src/i18n/langs/fr.js
@@ -145,6 +145,7 @@ const fr = {
     hide_window: 'Masquer la fenêtre',
     minimize_window: 'Réduire la fenêtre',
     maximize_window: 'Agrandir la fenêtre',
+    load_all_keys: 'tout charger',
   },
 };
 

--- a/src/i18n/langs/fr.js
+++ b/src/i18n/langs/fr.js
@@ -146,6 +146,7 @@ const fr = {
     minimize_window: 'Réduire la fenêtre',
     maximize_window: 'Agrandir la fenêtre',
     load_all_keys: 'tout charger',
+    can_load_all_keys: 'Activer le bouton pour charger toutes les clés',
   },
 };
 

--- a/src/i18n/langs/it.js
+++ b/src/i18n/langs/it.js
@@ -145,6 +145,7 @@ const it = {
     hide_window: 'Nascondi finestra',
     minimize_window: 'Riduci finestra',
     maximize_window: 'Massimizza finestra',
+    load_all_keys: 'carica tutto',
   },
 };
 

--- a/src/i18n/langs/it.js
+++ b/src/i18n/langs/it.js
@@ -146,6 +146,7 @@ const it = {
     minimize_window: 'Riduci finestra',
     maximize_window: 'Massimizza finestra',
     load_all_keys: 'carica tutto',
+    can_load_all_keys: 'Abilita pulsante per caricare tutte le chiavi',
   },
 };
 

--- a/src/i18n/langs/pt.js
+++ b/src/i18n/langs/pt.js
@@ -145,7 +145,8 @@ const pt = {
     hide_window: 'Ocultar janela',
     minimize_window: 'Minimize a janela',
     maximize_window: 'Maximize a janela',
-    load_all_keys: 'carregar todos',
+    load_all_keys: 'carregar todas',
+    can_load_all_keys: 'Habilite o botão para carregar todas as chaves',
   },
 };
 

--- a/src/i18n/langs/pt.js
+++ b/src/i18n/langs/pt.js
@@ -145,6 +145,7 @@ const pt = {
     hide_window: 'Ocultar janela',
     minimize_window: 'Minimize a janela',
     maximize_window: 'Maximize a janela',
+    load_all_keys: 'carregar todos',
   },
 };
 

--- a/src/i18n/langs/ru.js
+++ b/src/i18n/langs/ru.js
@@ -145,6 +145,7 @@ const ru = {
     hide_window: 'Скрыть окно',
     minimize_window: 'Свернуть окно',
     maximize_window: 'Развернуть окно',
+    load_all_keys: 'загрузить все',
   },
 };
 

--- a/src/i18n/langs/ru.js
+++ b/src/i18n/langs/ru.js
@@ -146,6 +146,7 @@ const ru = {
     minimize_window: 'Свернуть окно',
     maximize_window: 'Развернуть окно',
     load_all_keys: 'загрузить все',
+    can_load_all_keys: 'Кнопка включения для загрузки всех ключей',
   },
 };
 

--- a/src/i18n/langs/tr.js
+++ b/src/i18n/langs/tr.js
@@ -146,6 +146,7 @@ const tr = {
     minimize_window: 'Pencereleri küçültür',
     maximize_window: 'Pencereyi büyüt',
     load_all_keys: 'hepsini yükle',
+    can_load_all_keys: 'Tüm anahtarları yüklemek için etkinleştir düğmesi',
   },
 };
 

--- a/src/i18n/langs/tr.js
+++ b/src/i18n/langs/tr.js
@@ -145,6 +145,7 @@ const tr = {
     hide_window: 'Pencereyi gizle',
     minimize_window: 'Pencereleri küçültür',
     maximize_window: 'Pencereyi büyüt',
+    load_all_keys: 'hepsini yükle',
   },
 };
 

--- a/src/i18n/langs/tw.js
+++ b/src/i18n/langs/tw.js
@@ -145,6 +145,7 @@ const tw = {
     hide_window: '隱藏窗口',
     minimize_window: '最小化窗口',
     maximize_window: '最大化窗口',
+    load_all_keys: '加載所有',
   },
 };
 

--- a/src/i18n/langs/tw.js
+++ b/src/i18n/langs/tw.js
@@ -146,6 +146,7 @@ const tw = {
     minimize_window: '最小化窗口',
     maximize_window: '最大化窗口',
     load_all_keys: '加載所有',
+    can_load_all_keys: '啟用按鈕以加載所有鍵',
   },
 };
 

--- a/src/i18n/langs/ua.js
+++ b/src/i18n/langs/ua.js
@@ -146,6 +146,7 @@ const ua = {
     minimize_window: 'Згорнути вікно',
     maximize_window: 'Розгорнути вікно',
     load_all_keys: 'завантажити все',
+    can_load_all_keys: 'Кнопка «Увімкнути», щоб завантажити всі ключі',
   },
 };
 

--- a/src/i18n/langs/ua.js
+++ b/src/i18n/langs/ua.js
@@ -145,6 +145,7 @@ const ua = {
     hide_window: 'Сховати вікно',
     minimize_window: 'Згорнути вікно',
     maximize_window: 'Розгорнути вікно',
+    load_all_keys: 'завантажити все',
   },
 };
 


### PR DESCRIPTION
Allow users to load all keys at once, avoiding many clicks to achieve desire behaviour.

Config:

![image](https://user-images.githubusercontent.com/11843655/148222629-dc557fbf-ac26-4580-8c22-5a94368fef0d.png)

once the config it on will enable the `Load all` button in the main view
![image](https://user-images.githubusercontent.com/11843655/148222677-ad3c917a-110c-4bfa-abb9-091aec10ae0e.png)
