### PR TITLE
fix stream command dump id

### DIFF
--- a/src/components/KeyContentStream.vue
+++ b/src/components/KeyContentStream.vue
@@ -188,8 +188,8 @@ export default {
     dumpCommand(item) {
       const lines = item ? [item] : this.lineData;
       const params = lines.map(line => {
-        let command = `XADD ${this.$util.bufToQuotation(this.redisKey)} ${line.id} `;
-        
+        let command = `XADD ${this.$util.bufToQuotation(this.redisKey)} ${String(line.id).split('-')[0]} `;
+
         let dicts = [];
         for (const field in line.content) {
           dicts.push(this.$util.bufToQuotation(field), this.$util.bufToQuotation(line.content[field]));


### PR DESCRIPTION
这里导出的id的序列号是redis自动生成的，导出命令时不需要，可以截取掉