### PR TITLE
feat: add disable condition to delete_all button

### DIFF
--- a/src/components/DeleteBatch.vue
+++ b/src/components/DeleteBatch.vue
@@ -11,7 +11,7 @@
         Total: {{ Object.keys(allKeys).length }}
       </el-tag>
 
-      <el-button @click="confirmDelete" :disabled="loadingScan||loadingDelete" style="float: right;" type="danger">{{ $t('message.delete_all') }}</el-button>
+      <el-button @click="confirmDelete" :disabled="loadingScan||loadingDelete||Object.values(allKeys).length==0" style="float: right;" type="danger">{{ $t('message.delete_all') }}</el-button>
     </div>
 
     <!-- scan pattern -->


### PR DESCRIPTION
多选删除的时候，如果勾选项为0，点击 `Delete All` 按钮，程序会一直在 loading 状态。
所以，如果没有待删除的 key 的时候，删除按钮应该也处于 `disabled` 状态。

![image](https://user-images.githubusercontent.com/19246724/170659701-5bf4df21-1924-4455-aed1-81eaaf32ac8a.png)

![image](https://user-images.githubusercontent.com/19246724/170659752-f6344c6e-04b6-4eef-a5f5-c100866ad240.png)
