### PR TITLE
feat: add disable condition to delete_all button

### DIFF
--- a/src/components/DeleteBatch.vue
+++ b/src/components/DeleteBatch.vue
@@ -11,7 +11,7 @@
         Total: {{ Object.keys(allKeys).length }}
       </el-tag>
 
-      <el-button @click="confirmDelete" :disabled="loadingScan||loadingDelete" style="float: right;" type="danger">{{ $t('message.delete_all') }}</el-button>
+      <el-button @click="confirmDelete" :disabled="loadingScan||loadingDelete||Object.keys(allKeys).length == 0" style="float: right;" type="danger">{{ $t('message.delete_all') }}</el-button>
     </div>
 
     <!-- scan pattern -->


### PR DESCRIPTION
多选删除的时候，如果没有选择需要删除的内容就直接点击 `Delete All` 按钮的话，程序会一直处于 loading 状态，卡死在那里。
所以，当没有选择要删除的内容的时候，`Delete All` 按钮应该也处于 `disabled` 状态。

![image](https://user-images.githubusercontent.com/19246724/170666568-f86d0b99-8273-4d46-8125-1d7589e9c08d.png)

![image](https://user-images.githubusercontent.com/19246724/170666635-332cfdab-c146-46b9-9984-9f3dd6644b4d.png)
