### PR TITLE
feat: duplicate connection

### DIFF
--- a/src/components/ConnectionMenu.vue
+++ b/src/components/ConnectionMenu.vue
@@ -44,6 +44,10 @@
         <el-dropdown-item @click.native='showEditConnection'>
           <span><i class='more-operate-ico el-icon-edit-outline'></i>&nbsp;{{ $t('message.edit_connection') }}</span>
         </el-dropdown-item>
+        <el-dropdown-item @click.native='duplicateConnection'>
+          <span><i class='more-operate-ico fa fa-clone
+'></i>&nbsp;{{ $t('message.duplicate_connection') }}</span>
+        </el-dropdown-item>
         <el-dropdown-item @click.native='deleteConnection'>
           <span><i class='more-operate-ico el-icon-delete'></i>&nbsp;{{ $t('message.del_connection') }}</span>
         </el-dropdown-item>
@@ -110,6 +114,10 @@ export default {
       }).catch(() => {});
     },
     editConnectionFinished(newConfig) {
+      this.$bus.$emit('refreshConnections');
+    },
+    duplicateConnection() {
+      storage.duplicateConnection(this.config);
       this.$bus.$emit('refreshConnections');
     },
     deleteConnection() {

--- a/src/i18n/langs/cn.js
+++ b/src/i18n/langs/cn.js
@@ -3,6 +3,7 @@ const cn = {
     new_connection: '新建连接',
     refresh_connection: '刷新',
     edit_connection: '编辑连接',
+    duplicate_connection: '重复连接',
     del_connection: '删除连接',
     close_connection: '关闭连接',
     add_new_line: '添加新行',

--- a/src/i18n/langs/de.js
+++ b/src/i18n/langs/de.js
@@ -3,6 +3,7 @@ const de = {
     new_connection: 'Neue Verbindung',
     refresh_connection: 'Aktualisieren',
     edit_connection: 'Verbindung bearbeiten',
+    duplicate_connection: 'Doppelte Verbindung',
     del_connection: 'Verbindung löschen',
     close_connection: 'Verbindung schließen',
     add_new_line: 'Neue Zeile hinzufügen',

--- a/src/i18n/langs/en.js
+++ b/src/i18n/langs/en.js
@@ -3,6 +3,7 @@ const en = {
     new_connection: 'New Connection',
     refresh_connection: 'Refresh',
     edit_connection: 'Edit Connection',
+    duplicate_connection: 'Duplicate Connection',
     del_connection: 'Delete Connection',
     close_connection: 'Close Connection',
     add_new_line: 'Add New Line',

--- a/src/i18n/langs/es.js
+++ b/src/i18n/langs/es.js
@@ -3,6 +3,7 @@ const es = {
     new_connection: 'Nueva Conexión',
     refresh_connection: 'Refrescar',
     edit_connection: 'Editar Conexión',
+    duplicate_connection: 'Conexión duplicada',
     del_connection: 'Eliminar Conexión',
     close_connection: 'Cerrar Conexión',
     add_new_line: 'Añadir Nueva Linea',

--- a/src/i18n/langs/fr.js
+++ b/src/i18n/langs/fr.js
@@ -3,6 +3,7 @@ const fr = {
     new_connection: 'Nouvelle connexion',
     refresh_connection: 'Actualiser',
     edit_connection: 'Éditer connexion',
+    duplicate_connection: 'Connexion en double',
     del_connection: 'Supprimer connexion',
     close_connection: 'Fermer connexion',
     add_new_line: 'Ajouter nouvelle ligne',

--- a/src/i18n/langs/it.js
+++ b/src/i18n/langs/it.js
@@ -3,6 +3,7 @@ const it = {
     new_connection: 'Nuova Connessione',
     refresh_connection: 'Ricaricare',
     edit_connection: 'Modificare Connessione',
+    duplicate_connection: 'Doppia connessione',
     del_connection: 'Elimina Connessione',
     close_connection: 'Chiudere Connessione',
     add_new_line: 'Inserisci Nuova Riga',

--- a/src/i18n/langs/pt.js
+++ b/src/i18n/langs/pt.js
@@ -4,6 +4,7 @@ const pt = {
     refresh_connection: 'Atualizar',
     edit_connection: 'Editar Conexão',
     del_connection: 'Deletar Conexão',
+    duplicate_connection: 'Conexão duplicada',
     close_connection: 'Encerrar Conexão',
     add_new_line: 'Adicionar nova linha',
     dump_to_clipboard: "Copiar como comando",

--- a/src/i18n/langs/ru.js
+++ b/src/i18n/langs/ru.js
@@ -3,6 +3,7 @@ const ru = {
     new_connection: 'Новое подключение',
     refresh_connection: 'Обновить',
     edit_connection: 'Редактировать подключение',
+    duplicate_connection: 'Дублирующее подключение',
     del_connection: 'Удалить подключение',
     close_connection: 'Закрыть соединение',
     add_new_line: 'Добавить новую строку',

--- a/src/i18n/langs/tr.js
+++ b/src/i18n/langs/tr.js
@@ -3,6 +3,7 @@ const tr = {
     new_connection: 'Yeni Bağlantı',
     refresh_connection: 'Yenile',
     edit_connection: 'Bağlantıyı Düzenle',
+    duplicate_connection: 'Yinelenen bağlantı',
     del_connection: 'Bağlantıyı Sil',
     close_connection: 'Bağlantıyı Kapat',
     add_new_line: 'Yeni Satır Ekle',

--- a/src/i18n/langs/tw.js
+++ b/src/i18n/langs/tw.js
@@ -3,6 +3,7 @@ const tw = {
     new_connection: '新增連線',
     refresh_connection: '重新整理',
     edit_connection: '編輯連線',
+    duplicate_connection: '重複連接',
     del_connection: '刪除連線',
     close_connection: '關閉連線',
     add_new_line: '新增行',

--- a/src/i18n/langs/ua.js
+++ b/src/i18n/langs/ua.js
@@ -3,6 +3,7 @@ const ua = {
     new_connection: 'Нове з`єднання',
     refresh_connection: 'Оновити',
     edit_connection: 'Редагувати з`єднання',
+    duplicate_connection: 'Дубльоване підключення',
     del_connection: 'Видалити з`єднання',
     close_connection: 'Закрити з`єднання',
     add_new_line: 'Додати новий рядок',

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,3 +1,7 @@
+import utils from './util';
+
+const { addConnectionNameSuffix } = utils;
+
 export default {
   getSetting(key) {
     let settings = localStorage.getItem('settings');
@@ -93,7 +97,7 @@ export default {
     for (let key in connections) {
       // if 'name' same with others, add random suffix
       if (this.getConnectionName(connections[key]) == name) {
-        name += ` (${Math.random().toString(36).substr(-3)})`;
+        name = addConnectionNameSuffix(name);
         break;
       }
     }
@@ -102,6 +106,15 @@ export default {
   },
   getConnectionName(connection) {
     return connection.name || `${connection.host}@${connection.port}`;
+  },
+  duplicateConnection(connection) {
+    const newConnection = {
+      ...connection,
+      key: '',
+      name: addConnectionNameSuffix(connection.name),
+    };
+
+    this.addConnection(newConnection);
   },
   setConnections(connections) {
     localStorage.connections = JSON.stringify(connections);

--- a/src/util.js
+++ b/src/util.js
@@ -335,4 +335,7 @@ export default {
       }
     }
   },
+  addConnectionNameSuffix(name) {
+    return `${name} (${Math.random().toString(36).substr(-3)})`;
+  },
 };


### PR DESCRIPTION
Adds a `Duplicate Connection` option to the connection dropdown menu. 

<img width="1212" alt="Screenshot 2022-07-06 at 09 30 07" src="https://user-images.githubusercontent.com/8467936/177559992-4ed1ee40-0608-4daf-af13-dc0cad7d7a8c.png">

<img width="1212" alt="Screenshot 2022-07-06 at 14 24 03" src="https://user-images.githubusercontent.com/8467936/177560541-769d0f33-5859-4bc5-8a7a-e9e1895f963a.png">

# Notes

* Also abstracts utility to add random suffix to connection name.
* i18n translations were generated using google translate and should be verified.
* Consider allowing the user to edit the new duplicated connection before saving it, as most user use case will involve immediately editing the newly created connection.