### PR TITLE
Problems when pressing shift for multi-level selection.

### DIFF
--- a/src/components/KeyListVirtualTree.vue
+++ b/src/components/KeyListVirtualTree.vue
@@ -173,7 +173,7 @@ export default {
     showMultiSelect() {
       this.multiOperating = true;
       this.$refs.treeWrapper.classList.add('show-checkbox');
-      
+
       // adjust vtree height
       this.vtreeHeight = this.vtreeHeightMutiple;
     },
@@ -281,15 +281,19 @@ export default {
       const bottomKey = direction == 'up' ? this.lastKey : curKey;
 
       let start = false;
-      for (let item of this.$refs.veTree.dataList) {
-        if (!start) {
-          (item.key === topKey) && (start = true);
+      this.multilevelCheck(this.$refs.veTree.dataList,topKey, bottomKey,start);
+    },
+    multilevelCheck(dataList, topKey, bottomKey, start){
+      for(let item of dataList){
+        if(!start){
+          (item.key === topKey) && (start = true)
           continue;
         }
-
-        item.checked = this.lastChecked;
-
-        if (item.key === bottomKey) {
+        item.checked = this.lastChecked
+        if(item.childNodes.length > 0){
+          this.multilevelCheck(item.childNodes, topKey, bottomKey, true);
+        }
+        if(item.key === bottomKey){
           break;
         }
       }
@@ -376,7 +380,7 @@ export default {
 
 /*node item*/
 .key-list-vtree .el-tree-node {
-  font-size: 14px; 
+  font-size: 14px;
 }
 .key-list-vtree .el-tree-node .el-tree-node__content {
   padding-left: 3px;
@@ -461,8 +465,8 @@ export default {
 }
 /*select\cancel select all col*/
 .key-list-vtree .batch-operate .fixed-col {
-  float: left; 
-  width: 20px; 
+  float: left;
+  width: 20px;
   line-height: 22px;
 }
 /*second col*/


### PR DESCRIPTION
About the recurrence of this bug:
1.To enter the multiple selection mode, select a directory first
<img width="373" alt="image" src="https://user-images.githubusercontent.com/57079032/190098031-e26b3e75-4ec2-4322-8e81-8562d9ea978c.png">
2.When the following directories are not expanded, press and hold the Shift key to select multiple directories, you can see that 1-3 have been selected
<img width="373" alt="image" src="https://user-images.githubusercontent.com/57079032/190098375-312e455c-2a77-49a6-8861-a7baebcd80bb.png">
3.However, when we expand the middle directory, we can see that the sub elements are not selected
<img width="389" alt="image" src="https://user-images.githubusercontent.com/57079032/190098625-b39c1f49-3829-4ebb-9e7f-26e83ff01b04.png">

...Chinese English