### PR TITLE
feature: Fix the problem of connecting pure ipv6 domain names

### DIFF
--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -183,7 +183,7 @@ export default {
       // add additional host+port to options for "::1"
       host: host,
       port: port,
-      family: 6,
+      family: 0,
 
       connectTimeout: 30000,
       retryStrategy: (times) => {return this.retryStragety(times, {host, port})},

--- a/src/redisClient.js
+++ b/src/redisClient.js
@@ -183,6 +183,7 @@ export default {
       // add additional host+port to options for "::1"
       host: host,
       port: port,
+      family: 6,
 
       connectTimeout: 30000,
       retryStrategy: (times) => {return this.retryStragety(times, {host, port})},


### PR DESCRIPTION
修复一个由于ioredis的[RedisOptions.ts](https://github.com/luin/ioredis/blob/d9b1bf1/lib/redis/RedisOptions.ts#L192) 配置文件引起的问题。

ioredis默认设置family为4，这导致了在连接地址为 纯ipv6的域名 时，会报ENOTFOUND的错误。
![Snipaste_2023-02-12_13-17-27](https://user-images.githubusercontent.com/34988981/218294307-b2963e88-3b39-4cb9-9eb2-08f19ae87cea.png)

上游已经有了[相关的Pull Request](https://github.com/luin/ioredis/pull/1607)，但目前未被合并。所以提了这个Pull Request来修复这个问题。