### PR TITLE
Fix ViewerUnserialize: Turning off strict mode.

### DIFF
--- a/src/components/ViewerUnserialize.vue
+++ b/src/components/ViewerUnserialize.vue
@@ -13,7 +13,7 @@ export default {
   computed: {
     newContent() {
       try {
-        return unserialize(this.content);
+        return unserialize(this.content,{},{strict:false});
       } catch (e) {
         return this.$t('message.php_unserialize_format_failed');
       }


### PR DESCRIPTION
The strict mode is set to false for the unserialize function, in this way, PHP classes and objects stored in cache can be displayed correctly