### PR TITLE
README - Update fix command for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 ## Mac
 
-> If you can't open it after installation by brew or dmg, exec the following command then reopen:<br>`sudo xattr -rd com.apple.quarantine /Applications/Another\ Redis\ Desktop\ Manager.app`
+> If you can't open it after installation by brew or dmg, exec the following command then reopen:<br>`sudo xattr -d com.apple.quarantine /Applications/Another\ Redis\ Desktop\ Manager.app`
 
 - Download latest [dmg](https://github.com/qishibo/AnotherRedisDesktopManager/releases) package from release [or [gitee](https://gitee.com/qishibo/AnotherRedisDesktopManager/releases) in China], double click to install.
 - Or by **brew**: `brew install --cask another-redis-desktop-manager`


### PR DESCRIPTION
Hi

There is no `-r` arg for the `xattr` command anymore.

<img width="693" alt="image" src="https://github.com/qishibo/AnotherRedisDesktopManager/assets/16325641/118ddb28-274c-45c3-a5c5-97c4c05ac5a3">

This command is enough for fixing MacOS problem:

```bash
sudo xattr -d com.apple.quarantine /Applications/Another\ Redis\ Desktop\ Manager.app
```