### PR TITLE
fixed php unserialize null error

### DIFF
--- a/src/components/viewers/ViewerPHPSerialize.vue
+++ b/src/components/viewers/ViewerPHPSerialize.vue
@@ -20,8 +20,7 @@ export default {
       try {
         const content = unserialize(this.content, {}, { strict: false });
 
-        // include php native class, into readonly mode
-        if (content['__PHP_Incomplete_Class_Name']) {
+        if (content && content['__PHP_Incomplete_Class_Name']) {
           this.isPHPClass = true;
         }
 


### PR DESCRIPTION
php unserialize fails if the `php-serialize` library returns `null` (e.g. unserializing `N;`). Trying to read the `__PHP_Incomplete_Class_Name` property of null causes the error. Added a simple check for that.