### PR TITLE
change ExportKey behavior when right click on key

### DIFF
--- a/src/components/KeyListVirtualTree.vue
+++ b/src/components/KeyListVirtualTree.vue
@@ -260,8 +260,13 @@ export default {
           break;
         }
         case 'export': {
+          this.$refs.veTree.setChecked(this.rightClickNode.key, true);
+
+          if (this.multiOperating) {
+            return this.exportBatch();
+          }
+
           this.showMultiSelect();
-          this.exportBatch();
           break;
         }
         case 'load_cur_folder': {


### PR DESCRIPTION
Actually, when you right click a key, it prompt `"Please select keys!"` and don't select none, neither export

This PR change this behavior to:
- If in multi select mode, export all the selected keys, plus the one you right clicked
- If in single mode, enter multi select key, with the key you right clicked selected