### PR TITLE
add group manage for connections

### DIFF
--- a/src/components/ConnectionWrapper.vue
+++ b/src/components/ConnectionWrapper.vue
@@ -244,7 +244,7 @@ export default {
 <style type="text/css">
   /*menu ul*/
   .connection-menu {
-    margin-bottom: 8px;
+    margin-bottom: 4px;
     padding-right: 6px;
     border-right: 0;
   }
@@ -258,5 +258,34 @@ export default {
   /*this error shows first*/
   .redis-on-error-message {
     z-index:9999 !important;
+  }
+
+  /* Set connection item height */
+  .connection-menu .el-submenu__title {
+    height: 28px !important;
+    line-height: 28px !important;
+  }
+
+  .connection-menu .el-menu-item {
+    height: 28px !important;
+    line-height: 28px !important;
+  }
+
+  .connection-menu .el-submenu .el-menu-item {
+    height: 28px !important;
+    line-height: 28px !important;
+  }
+
+  /* Reduce spacing between items */
+  .connection-menu .el-menu-item {
+    margin: 0 !important;
+  }
+
+  .connection-menu .el-submenu {
+    margin: 0 !important;
+  }
+
+  .connection-menu .el-menu {
+    padding: 0 !important;
   }
 </style>

--- a/src/components/ConnectionWrapper.vue
+++ b/src/components/ConnectionWrapper.vue
@@ -13,7 +13,8 @@
         :config="config"
         :client='client'
         @changeColor='setColor'
-        @refreshConnection='openConnection(false, true)'>
+        @refreshConnection='openConnection(false, true)'
+        class="connection-header">
       </ConnectionMenu>
 
       <!-- db search operate -->

--- a/src/components/Connections.vue
+++ b/src/components/Connections.vue
@@ -1,25 +1,42 @@
 <template>
   <div class="connections-wrap">
-    <!-- search connections input -->
-    <div v-if="connections.length>=filterEnableNum" class="filter-input">
-      <el-input
-        v-model="filterMode"
-        suffix-icon="el-icon-search"
-        :placeholder="$t('message.search_connection')"
-        clearable
-        size="mini">
+    <!-- filter input and new group button -->
+    <div class="connections-header">
+      <el-input v-model="filterText" :placeholder="$t('message.filter_connections')" prefix-icon="el-icon-search" clearable class="filter-input">
       </el-input>
+      <el-button type="text" icon="el-icon-plus" @click="createNewGroup" class="new-group-btn">
+        {{ $t('message.new_group') }}
+      </el-button>
     </div>
 
     <!-- connections list -->
-    <div class="connections-list">
-      <ConnectionWrapper
-        v-for="item, index of filteredConnections"
-        :key="item.key ? item.key : item.connectionName"
-        :index="index"
-        :globalSettings="globalSettings"
-        :config='item'>
-      </ConnectionWrapper>
+    <div class="connections-list" ref="groupsList">
+      <!-- grouped connections -->
+      <div v-for="(group, groupId) in groupedConnections" :key="groupId" class="connection-group">
+        <div class="group-header" :data-group="groupId">
+          <div class="group-header-left" @click="toggleGroupCollapse(groupId)">
+            <i :class="['el-icon-arrow-down', 'collapse-icon', { 'is-collapsed': isGroupCollapsed(groupId) }]">
+            </i>
+            <span v-if="editingGroup != groupId">{{ getGroupNameById(groupId) || $t('message.default_group') }}</span>
+            <el-input v-else v-model="editingGroupName" size="small" @blur="finishEditGroup" @keyup.enter.native="finishEditGroup" @keyup.esc.native="cancelEditGroup" ref="groupNameInput" class="group-name-input">
+            </el-input>
+          </div>
+          <div class="group-header-right" draggable="true" @dragstart="onGroupDragStart" @dragend="onGroupDragEnd">
+            <div class="group-actions" v-if="groupId && groupId != 1">
+              <el-button type="text" icon="el-icon-edit" @click="startEditGroup(groupId)" class="group-action-btn">
+              </el-button>
+              <el-button type="text" icon="el-icon-delete" @click="deleteGroup(groupId)" class="group-action-btn">
+              </el-button>
+            </div>
+          </div>
+        </div>
+        <div class="group-connections" :data-group="groupId" v-show="!isGroupCollapsed(groupId)">
+          <div v-for="connection in group" :key="connection.key" class="connection-wrapper" :data-key="connection.key">
+            <ConnectionWrapper :config="connection" :globalSettings="globalSettings" :index="connection.key">
+            </ConnectionWrapper>
+          </div>
+        </div>
+      </div>
     </div>
 
     <ScrollToTop parentNum='1' :posRight='false'></ScrollToTop>
@@ -32,14 +49,20 @@ import ConnectionWrapper from '@/components/ConnectionWrapper';
 import ScrollToTop from '@/components/ScrollToTop';
 import Sortable from 'sortablejs';
 
-
 export default {
   data() {
     return {
       connections: [],
+      groups: [],
+      groupOrder: [],
+      collapsedGroups: [],
       globalSettings: this.$storage.getSetting(),
-      filterEnableNum: 4,
-      filterMode: '',
+      filterText: '',
+      editingGroup: null,
+      editingGroupName: '',
+      sortableInstances: [],
+      dragStartY: 0,
+      dragStartX: 0
     };
   },
   components: { ConnectionWrapper, ScrollToTop },
@@ -53,67 +76,647 @@ export default {
   },
   computed: {
     filteredConnections() {
-      if (!this.filterMode) {
+      if (!this.filterText) {
         return this.connections;
       }
 
-      return this.connections.filter(item => {
-        return item.name.toLowerCase().includes(this.filterMode.toLowerCase());
+      const filter = this.filterText.toLowerCase();
+      return this.connections.filter(conn => {
+        const groupName = this.getGroupNameById(conn.groupId);
+        return (conn.connectionName && conn.connectionName.toLowerCase().includes(filter)) ||
+          (conn.host && conn.host.toLowerCase().includes(filter)) ||
+          (groupName && groupName.toLowerCase().includes(filter));
       });
     },
+    groupedConnections() {
+      const groups = {};
+      const defaultGroupId = 1;
+
+      // 首先添加默认分组
+      groups[defaultGroupId] = [];
+
+      // 按照保存的顺序添加其他分组
+      this.groupOrder.forEach(groupId => {
+        // 只添加存在的分组
+        if (groupId != defaultGroupId && this.groups.some(g => g.id == groupId)) {
+          groups[groupId] = [];
+        }
+      });
+
+      // 添加连接到对应的分组
+      this.filteredConnections.forEach(conn => {
+        const groupId = conn.groupId || defaultGroupId;
+        if (!groups[groupId]) {
+          groups[groupId] = [];
+        }
+        groups[groupId].push(conn);
+      });
+
+      return groups;
+    }
   },
   methods: {
+    getGroupNameById(groupId) {
+      const group = this.groups.find(g => g.id == groupId);
+      return group ? group.name : this.$t('message.default_group');
+    },
+    getGroupById(groupId) {
+      return this.groups.find(g => g.id == groupId);
+    },
     initConnections() {
       const connections = storage.getConnections(true);
       const slovedConnections = [];
-      // this.connections = [];
 
       for (const item of connections) {
         item.connectionName = storage.getConnectionName(item);
-        // fix history bug, prevent db into config
         delete item.db;
         slovedConnections.push(item);
       }
 
       this.connections = slovedConnections;
+      this.groups = storage.getGroups();
+
+      // 只在初始化时设置分组顺序
+      if (!this.groupOrder.length) {
+        this.initGroupOrder();
+      }
+
+      // 初始化折叠状态
+      this.initCollapsedGroups();
+
+      this.initSortable();
     },
-    sortOrder() {
-      const dragWrapper = document.querySelector('.connections-list');
-      Sortable.create(dragWrapper, {
-        handle: '.el-submenu__title',
-        animation: 400,
-        direction: 'vertical',
-        onEnd: (e) => {
-          const { newIndex } = e;
-          const { oldIndex } = e;
-          // change in connections
-          const currentRow = this.connections.splice(oldIndex, 1)[0];
-          this.connections.splice(newIndex, 0, currentRow);
-          // store
-          this.$storage.reOrderAndStore(this.connections);
-        },
+    initGroupOrder() {
+      // 从 localStorage 获取保存的分组顺序
+      const savedOrder = localStorage.getItem('groupOrder');
+      if (savedOrder) {
+        this.groupOrder = JSON.parse(savedOrder);
+        // 确保所有分组都在顺序列表中
+        this.groups.forEach(group => {
+          if (!this.groupOrder.includes(group.id)) {
+            this.groupOrder.push(group.id);
+          }
+        });
+      } else {
+        // 如果没有保存的顺序，使用默认顺序
+        this.groupOrder = [1]; // 默认分组 id 为 1
+        this.groups.forEach(group => {
+          if (group.id != 1) {
+            this.groupOrder.push(group.id);
+          }
+        });
+      }
+      // 保存更新后的顺序
+      this.saveGroupOrder();
+    },
+    saveGroupOrder() {
+      localStorage.setItem('groupOrder', JSON.stringify(this.groupOrder));
+    },
+    createNewGroup() {
+      const baseName = this.$t('message.new_group');
+      let newGroupName = baseName;
+      let counter = 1;
+
+      // 检查是否存在同名分组，如果存在则添加数字后缀
+      while (this.groups.some(g => g.name == newGroupName)) {
+        newGroupName = `${baseName} ${counter}`;
+        counter++;
+      }
+
+      // 生成新的分组 id
+      const maxId = Math.max(...this.groups.map(g => g.id || 0), 1);
+      const newGroupId = maxId + 1;
+
+      const newGroup = {
+        id: newGroupId,
+        name: newGroupName
+      };
+
+      // 添加到 groups 数组
+      this.groups.push(newGroup);
+
+      // 保存到存储
+      storage.setGroups(this.groups);
+
+      // 添加到分组顺序
+      this.groupOrder.push(newGroupId);
+      this.saveGroupOrder();
+
+      // 刷新连接列表
+      this.initConnections();
+      this.$message.success(this.$t('message.save_group_success'));
+    },
+    startEditGroup(groupId) {
+      if (groupId == 1) { // 默认分组不能编辑
+        return;
+      }
+      const group = this.getGroupById(groupId);
+      if (!group) return;
+
+      this.editingGroup = groupId;
+      this.editingGroupName = group.name;
+      
+      // 禁用分组拖动
+      this.setGroupSortableEnabled(false);
+      
+      this.$nextTick(() => {
+        if (this.$refs.groupNameInput) {
+          this.$refs.groupNameInput[0].focus();
+        }
       });
     },
+    finishEditGroup() {
+      if (!this.editingGroup || !this.editingGroupName.trim()) {
+        this.editingGroup = null;
+        // 重新启用分组拖动
+        this.setGroupSortableEnabled(true);
+        return;
+      }
+
+      const newName = this.editingGroupName.trim();
+      const group = this.getGroupById(this.editingGroup);
+      if (!group || newName == group.name) {
+        this.editingGroup = null;
+        // 重新启用分组拖动
+        this.setGroupSortableEnabled(true);
+        return;
+      }
+
+      // 更新分组名称
+      group.name = newName;
+
+      // 更新存储
+      storage.setGroups(this.groups);
+      this.$storage.reOrderAndStore(this.connections);
+
+      // 刷新连接列表
+      this.initConnections();
+      this.editingGroup = null;
+      
+      // 重新启用分组拖动
+      this.setGroupSortableEnabled(true);
+      
+      this.$message.success(this.$t('message.save_group_success'));
+    },
+    deleteGroup(groupId) {
+      if (groupId == 1) { // 默认分组不能删除
+        return;
+      }
+      this.$confirm(this.$t('message.delete_group_confirm'), this.$t('message.warning'), {
+        confirmButtonText: this.$t('message.confirm'),
+        cancelButtonText: this.$t('message.cancel'),
+        type: 'warning'
+      }).then(() => {
+        // 将该分组的所有连接移到默认分组
+        this.connections.forEach(conn => {
+          if (conn.groupId == groupId) {
+            conn.groupId = 1;
+          }
+        });
+
+        // 删除分组
+        storage.deleteGroup(groupId);
+
+        // 从 groupOrder 中删除
+        const orderIndex = this.groupOrder.indexOf(groupId);
+        if (orderIndex > -1) {
+          this.groupOrder.splice(orderIndex, 1);
+        }
+
+        // 从 collapsedGroups 中删除
+        const collapsedIndex = this.collapsedGroups.indexOf(groupId);
+        if (collapsedIndex > -1) {
+          this.collapsedGroups.splice(collapsedIndex, 1);
+        }
+
+        // 保存更改
+        this.$storage.reOrderAndStore(this.connections);
+        this.saveGroupOrder();
+        this.saveCollapsedGroups();
+
+        // 刷新连接列表
+        this.initConnections();
+        this.$message.success(this.$t('message.delete_group_success'));
+      }).catch(() => {});
+    },
+    onGroupDragStart(event) {
+      const header = event.target.closest('.group-header');
+      if (!header) return;
+
+      header.classList.add('dragging');
+      event.dataTransfer.setData('text/plain', header.dataset.group);
+    },
+    onGroupDragEnd(event) {
+      const header = event.target.closest('.group-header');
+      if (!header) return;
+
+      header.classList.remove('dragging');
+    },
+    initSortable() {
+      // 清理之前的实例
+      this.sortableInstances.forEach(instance => instance.destroy());
+      this.sortableInstances = [];
+
+      // 为分组列表创建 Sortable 实例
+      this.$nextTick(() => {
+        const groupsList = this.$refs.groupsList;
+        const sortable = new Sortable(groupsList, {
+          handle: '.group-header',
+          animation: 150,
+          ghostClass: 'sortable-ghost',
+          dragClass: 'sortable-drag',
+          forceFallback: true,
+          fallbackClass: 'sortable-fallback',
+          fallbackOnBody: true,
+          scroll: true,
+          scrollSensitivity: 30,
+          scrollSpeed: 10,
+          direction: 'vertical',
+          preventOnFilter: true,
+          draggable: '.connection-group',
+          invertSwap: true,
+          swapThreshold: 0.5,
+          onStart: (evt) => {
+            this.dragStartY = evt.clientY;
+            this.dragStartX = evt.clientX;
+          },
+          onMove: (evt) => {
+            const deltaY = Math.abs(evt.clientY - this.dragStartY);
+            const deltaX = Math.abs(evt.clientX - this.dragStartX);
+            if (deltaX > deltaY) {
+              return false;
+            }
+            return true;
+          },
+          onEnd: (evt) => {
+            const newOrder = [];
+            const groups = groupsList.querySelectorAll('.connection-group');
+            groups.forEach(group => {
+              const groupId = group.querySelector('.group-header').dataset.group;
+              newOrder.push(groupId);
+            });
+            this.groupOrder = newOrder;
+            this.saveGroupOrder();
+          }
+        });
+        this.sortableInstances.push(sortable);
+
+        // 为每个分组内的连接创建 Sortable 实例
+        const groupContainers = document.querySelectorAll('.group-connections');
+        groupContainers.forEach(container => {
+          const sortable = new Sortable(container, {
+            group: 'connections',
+            animation: 150,
+            ghostClass: 'sortable-ghost',
+            dragClass: 'sortable-drag',
+            forceFallback: true,
+            fallbackClass: 'sortable-fallback',
+            fallbackOnBody: true,
+            scroll: true,
+            scrollSensitivity: 30,
+            scrollSpeed: 10,
+            direction: 'vertical',
+            preventOnFilter: true,
+            invertSwap: true,
+            swapThreshold: 0.5,
+            onStart: (evt) => {
+              this.dragStartY = evt.clientY;
+              this.dragStartX = evt.clientX;
+            },
+            onMove: (evt) => {
+              const deltaY = Math.abs(evt.clientY - this.dragStartY);
+              const deltaX = Math.abs(evt.clientX - this.dragStartX);
+              if (deltaX > deltaY) {
+                return false;
+              }
+              return true;
+            },
+            onEnd: (evt) => {
+              const targetGroupId = evt.to.dataset.group;
+              const sourceGroupId = evt.from.dataset.group;
+              const connectionKey = evt.item.dataset.key;
+
+              if (sourceGroupId == targetGroupId) {
+                // 同一分组内移动，更新连接顺序
+                const newConnections = [];
+                const groupConnections = this.connections.filter(conn =>
+                  (conn.groupId || 1) == targetGroupId
+                );
+
+                // 获取分组内所有连接的新顺序
+                const groupContainer = evt.to;
+                const connectionElements = groupContainer.querySelectorAll('.connection-wrapper');
+                connectionElements.forEach(element => {
+                  const key = element.dataset.key;
+                  const connection = groupConnections.find(conn => conn.key == key);
+                  if (connection) {
+                    newConnections.push(connection);
+                  }
+                });
+
+                // 更新连接顺序
+                this.connections = this.connections.filter(conn =>
+                  (conn.groupId || 1) != targetGroupId
+                );
+                this.connections.push(...newConnections);
+              } else {
+                // 不同分组间移动，更新连接的分组
+                const connection = this.connections.find(conn => conn.key == connectionKey);
+                if (connection) {
+                  connection.groupId = targetGroupId == 1 ? null : targetGroupId;
+                }
+              }
+
+              // 保存更改
+              this.$storage.reOrderAndStore(this.connections);
+              this.initConnections();
+            }
+          });
+          this.sortableInstances.push(sortable);
+        });
+      });
+    },
+    initCollapsedGroups() {
+      // 从 localStorage 获取保存的折叠状态
+      const savedCollapsedGroups = localStorage.getItem('collapsedGroups');
+      if (savedCollapsedGroups) {
+        this.collapsedGroups = JSON.parse(savedCollapsedGroups);
+      }
+    },
+    saveCollapsedGroups() {
+      localStorage.setItem('collapsedGroups', JSON.stringify(this.collapsedGroups));
+    },
+    isGroupCollapsed(groupId) {
+      return this.collapsedGroups.includes(groupId);
+    },
+    toggleGroupCollapse(groupId) {
+      if (this.isDragging) return;
+
+      // 使用 nextTick 确保在 DOM 更新后执行
+      this.$nextTick(() => {
+        const index = this.collapsedGroups.indexOf(groupId);
+        if (index == -1) {
+          this.collapsedGroups.push(groupId);
+        } else {
+          this.collapsedGroups.splice(index, 1);
+        }
+        this.saveCollapsedGroups();
+      });
+    },
+    setGroupSortableEnabled(enabled) {
+      // 找到分组的 Sortable 实例（第一个实例是分组拖动实例）
+      if (this.sortableInstances.length > 0) {
+        const groupSortable = this.sortableInstances[0];
+        if (groupSortable && groupSortable.option) {
+          groupSortable.option('disabled', !enabled);
+        }
+      }
+    },
+    cancelEditGroup() {
+      this.editingGroup = null;
+      // 重新启用分组拖动
+      this.setGroupSortableEnabled(true);
+    }
   },
   mounted() {
     this.initConnections();
-    this.sortOrder();
   },
+  beforeDestroy() {
+    // 清理 Sortable 实例
+    this.sortableInstances.forEach(instance => instance.destroy());
+  }
 };
 </script>
 
 <style type="text/css">
-  .connections-wrap {
-    height: calc(100vh - 59px);
-    overflow-y: auto;
-    margin-top: 11px;
-  }
-  .connections-wrap .filter-input {
-    padding-right: 13px;
-    margin-bottom: 4px;
-  }
-  /* set drag area min height, target to the end will be correct */
-  .connections-wrap .connections-list {
-    min-height: calc(100vh - 110px);
-  }
+.connections-wrap {
+  height: calc(100vh - 59px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  margin-top: 11px;
+}
+
+.connections-header {
+  display: flex;
+  align-items: center;
+  margin: 0 13px 4px 0;
+}
+
+.connections-wrap .filter-input {
+  flex: 1;
+}
+
+.new-group-btn {
+  margin-left: 8px;
+}
+
+.connections-wrap .connections-list {
+  min-height: calc(100vh - 110px);
+}
+
+.connection-group {
+  margin-bottom: 4px;
+  position: relative;
+  z-index: 1;
+}
+
+.group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 16px;
+  font-size: 13px;
+  color: #909399;
+  font-weight: bold;
+  background-color: #f5f7fa;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  user-select: none;
+  transition: background-color 0.2s;
+  position: relative;
+  z-index: 1;
+  min-height: 24px;
+}
+
+.group-header-left {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  min-width: 0;
+  cursor: pointer;
+  padding: 0;
+}
+
+.group-header-left:hover {
+  background-color: transparent;
+}
+
+.dark-mode .group-header-left:hover {
+  background-color: transparent;
+}
+
+.group-header-right {
+  display: flex;
+  align-items: center;
+  cursor: move;
+  padding: 0;
+  margin-left: 8px;
+}
+
+.group-header-right:hover {
+  background-color: transparent;
+}
+
+.dark-mode .group-header-right:hover {
+  background-color: transparent;
+}
+
+.collapse-icon {
+  margin-right: 6px;
+  transition: transform 0.3s;
+  font-size: 12px;
+  color: #909399;
+  line-height: 24px;
+}
+
+.collapse-icon.is-collapsed {
+  transform: rotate(-90deg);
+}
+
+.group-actions {
+  display: flex;
+  align-items: center;
+}
+
+.group-action-btn {
+  padding: 0 2px;
+  height: 20px;
+  line-height: 20px;
+}
+
+.group-action-btn i {
+  font-size: 13px;
+}
+
+.group-name-input {
+  flex: 1;
+  margin-right: 8px;
+}
+
+.group-name-input .el-input__inner {
+  height: 20px;
+  line-height: 20px;
+  font-size: 13px;
+  font-weight: bold;
+  color: #909399;
+  background-color: transparent;
+  border: 1px solid #dcdfe6;
+}
+
+.group-name-input .el-input__inner:focus {
+  border-color: #409eff;
+}
+
+.dark-mode .group-header {
+  background-color: #2b2b2b;
+  color: #909399;
+}
+
+.dark-mode .group-name-input .el-input__inner {
+  background-color: transparent;
+  color: #909399;
+  border-color: #4c4d4f;
+}
+
+.dark-mode .group-name-input .el-input__inner:focus {
+  border-color: #409eff;
+}
+
+.dark-mode .group-header:hover {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+/* Connection indentation */
+.connection-group .connection-menu {
+  margin-left: 16px;
+  margin-top: 4px;
+}
+
+.connection-group .connection-menu .el-submenu__title {
+  padding-left: 16px !important;
+}
+
+.connection-group .connection-menu .el-menu-item {
+  padding-left: 16px !important;
+}
+
+.connection-group .connection-menu .el-submenu .el-menu-item {
+  padding-left: 28px !important;
+}
+
+/* Drag and drop styles */
+.connection-wrapper {
+  cursor: move;
+}
+
+.connection-wrapper.dragging {
+  opacity: 0.5;
+}
+
+.group-connections {
+  min-height: 28px;
+  transition: background-color 0.2s;
+  padding-top: 4px;
+}
+
+.group-connections.drag-over {
+  background-color: rgba(64, 158, 255, 0.1);
+}
+
+.dark-mode .group-connections.drag-over {
+  background-color: rgba(64, 158, 255, 0.2);
+}
+
+/* Sortable styles */
+.sortable-fallback {
+  opacity: 0.8;
+  background: #fff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  pointer-events: none;
+}
+
+.dark-mode .sortable-fallback {
+  background: #1f1f1f;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.sortable-ghost {
+  opacity: 0.5;
+  background: #f0f0f0;
+  pointer-events: none;
+}
+
+.sortable-drag {
+  opacity: 0.8;
+  background: #fff;
+  pointer-events: none;
+}
+
+.dark-mode .sortable-ghost {
+  background: #2b2b2b;
+}
+
+.dark-mode .sortable-drag {
+  background: #1f1f1f;
+}
+
+.group-header.dragging {
+  opacity: 0.5;
+  z-index: 2;
+}
+
+.connection-group.sortable-ghost {
+  z-index: 0;
+}
 </style>

--- a/src/components/Connections.vue
+++ b/src/components/Connections.vue
@@ -367,6 +367,7 @@ export default {
         groupContainers.forEach(container => {
           const sortable = new Sortable(container, {
             group: 'connections',
+            handle: '.connection-header',
             animation: 150,
             ghostClass: 'sortable-ghost',
             dragClass: 'sortable-drag',
@@ -378,8 +379,12 @@ export default {
             scrollSpeed: 10,
             direction: 'vertical',
             preventOnFilter: true,
+            filter: '.connection-opt-icons, .connection-opt-icons *',
             invertSwap: true,
             swapThreshold: 0.5,
+            delay: 50,
+            delayOnTouchOnly: false,
+            distance: 10,
             onStart: (evt) => {
               this.dragStartY = evt.clientY;
               this.dragStartX = evt.clientX;
@@ -658,7 +663,11 @@ export default {
 
 /* Drag and drop styles */
 .connection-wrapper {
-  cursor: move;
+  cursor: default;
+}
+
+.connection-header {
+  cursor: default;
 }
 
 .connection-wrapper.dragging {

--- a/src/i18n/langs/cn.js
+++ b/src/i18n/langs/cn.js
@@ -173,6 +173,15 @@ const cn = {
     theme_system: '跟随系统',
     theme_light: '亮色模式',
     theme_dark: '暗色模式',
+    new_group: '新分组',
+    default_group: '默认分组',
+    save_group_success: '保存分组成功',
+    delete_group_confirm: '确认删除该分组？',
+    delete_group_success: '删除分组成功',
+    warning: '警告',
+    confirm: '确认',
+    cancel: '取消',
+    filter_connections: '搜索连接'
   },
 };
 

--- a/src/i18n/langs/de.js
+++ b/src/i18n/langs/de.js
@@ -173,6 +173,15 @@ const de = {
     theme_system: 'System',
     theme_light: 'Licht',
     theme_dark: 'Dunkel',
+    new_group: 'Neue Gruppe',
+    default_group: 'Standardgruppe',
+    save_group_success: 'Gruppe erfolgreich gespeichert',
+    delete_group_confirm: 'Möchten Sie diese Gruppe wirklich löschen?',
+    delete_group_success: 'Gruppe erfolgreich gelöscht',
+    warning: 'Warnung',
+    confirm: 'Bestätigen',
+    cancel: 'Abbrechen',
+    filter_connections: 'Verbindungen suchen'
   },
 };
 

--- a/src/i18n/langs/en.js
+++ b/src/i18n/langs/en.js
@@ -173,6 +173,15 @@ const en = {
     theme_system: 'System',
     theme_light: 'Light',
     theme_dark: 'Dark',
+    new_group: 'New Group',
+    default_group: 'Default Group',
+    save_group_success: 'Group saved successfully',
+    delete_group_confirm: 'Confirm to delete this group?',
+    delete_group_success: 'Group deleted successfully',
+    warning: 'Warning',
+    confirm: 'Confirm',
+    cancel: 'Cancel',
+    filter_connections: 'Search connections'
   },
 };
 

--- a/src/i18n/langs/es.js
+++ b/src/i18n/langs/es.js
@@ -173,6 +173,15 @@ const es = {
     theme_system: 'Sistema',
     theme_light: 'Luz',
     theme_dark: 'Oscuro',
+    new_group: 'Nuevo grupo',
+    default_group: 'Grupo predeterminado',
+    save_group_success: 'Grupo guardado con éxito',
+    delete_group_confirm: '¿Confirmar la eliminación de este grupo?',
+    delete_group_success: 'Grupo eliminado con éxito',
+    warning: 'Advertencia',
+    confirm: 'Confirmar',
+    cancel: 'Cancelar',
+    filter_connections: 'Buscar conexiones'
   },
 };
 

--- a/src/i18n/langs/fr.js
+++ b/src/i18n/langs/fr.js
@@ -173,6 +173,15 @@ const fr = {
     theme_system: 'Système',
     theme_light: 'Lumière',
     theme_dark: 'Sombre',
+    new_group: 'Nouveau groupe',
+    default_group: 'Groupe par défaut',
+    save_group_success: 'Groupe enregistré avec succès',
+    delete_group_confirm: 'Confirmer la suppression de ce groupe ?',
+    delete_group_success: 'Groupe supprimé avec succès',
+    warning: 'Avertissement',
+    confirm: 'Confirmer',
+    cancel: 'Annuler',
+    filter_connections: 'Rechercher des connexions'
   },
 };
 

--- a/src/i18n/langs/it.js
+++ b/src/i18n/langs/it.js
@@ -173,6 +173,15 @@ const it = {
     theme_system: 'Sistema',
     theme_light: 'Luce',
     theme_dark: 'Scuro',
+    new_group: 'Nuovo gruppo',
+    default_group: 'Gruppo predefinito',
+    save_group_success: 'Gruppo salvato con successo',
+    delete_group_confirm: 'Confermi di eliminare questo gruppo?',
+    delete_group_success: 'Gruppo eliminato con successo',
+    warning: 'Avviso',
+    confirm: 'Conferma',
+    cancel: 'Annulla',
+    filter_connections: 'Cerca connessioni'
   },
 };
 

--- a/src/i18n/langs/ko.js
+++ b/src/i18n/langs/ko.js
@@ -173,6 +173,15 @@ const ko = {
     theme_system: '시스템',
     theme_light: '밝은 색',
     theme_dark: '어두운 색',
+    new_group: '새 그룹',
+    default_group: '기본 그룹',
+    save_group_success: '그룹이 성공적으로 저장되었습니다',
+    delete_group_confirm: '이 그룹을 삭제하시겠습니까?',
+    delete_group_success: '그룹이 성공적으로 삭제되었습니다',
+    warning: '경고',
+    confirm: '확인',
+    cancel: '취소',
+    filter_connections: '연결 검색'
   },
 };
 

--- a/src/i18n/langs/pt.js
+++ b/src/i18n/langs/pt.js
@@ -173,6 +173,15 @@ const pt = {
     theme_system: 'Sistema',
     theme_light: 'Luz',
     theme_dark: 'Escuro',
+    new_group: 'Novo grupo',
+    default_group: 'Grupo padrão',
+    save_group_success: 'Grupo salvo com sucesso',
+    delete_group_confirm: 'Confirmar exclusão deste grupo?',
+    delete_group_success: 'Grupo excluído com sucesso',
+    warning: 'Aviso',
+    confirm: 'Confirmar',
+    cancel: 'Cancelar',
+    filter_connections: 'Buscar conexões'
   },
 };
 

--- a/src/i18n/langs/ru.js
+++ b/src/i18n/langs/ru.js
@@ -173,6 +173,15 @@ const ru = {
     theme_system: 'Системы',
     theme_light: 'Свет',
     theme_dark: 'Тёмный',
+    new_group: 'Новая группа',
+    default_group: 'Группа по умолчанию',
+    save_group_success: 'Группа успешно сохранена',
+    delete_group_confirm: 'Подтвердите удаление этой группы?',
+    delete_group_success: 'Группа успешно удалена',
+    warning: 'Предупреждение',
+    confirm: 'Подтвердить',
+    cancel: 'Отмена',
+    filter_connections: 'Поиск подключений'
   },
 };
 

--- a/src/i18n/langs/tr.js
+++ b/src/i18n/langs/tr.js
@@ -173,6 +173,15 @@ const tr = {
     theme_system: 'Sistem',
     theme_light: 'Işık',
     theme_dark: 'Karanlık',
+    new_group: 'Yeni grup',
+    default_group: 'Varsayılan grup',
+    save_group_success: 'Grup başarıyla kaydedildi',
+    delete_group_confirm: 'Bu grubu silmek istediğinizden emin misiniz?',
+    delete_group_success: 'Grup başarıyla silindi',
+    warning: 'Uyarı',
+    confirm: 'Onayla',
+    cancel: 'İptal',
+    filter_connections: 'Bağlantıları ara'
   },
 };
 

--- a/src/i18n/langs/tw.js
+++ b/src/i18n/langs/tw.js
@@ -173,6 +173,15 @@ const tw = {
     theme_system: '跟隨系統',
     theme_light: '亮色模式',
     theme_dark: '暗色模式',
+    new_group: '新分組',
+    default_group: '默認分組',
+    save_group_success: '保存分組成功',
+    delete_group_confirm: '確認刪除該分組？',
+    delete_group_success: '刪除分組成功',
+    warning: '警告',
+    confirm: '確認',
+    cancel: '取消',
+    filter_connections: '搜索連接'
   },
 };
 

--- a/src/i18n/langs/ua.js
+++ b/src/i18n/langs/ua.js
@@ -173,6 +173,15 @@ const ua = {
     theme_system: 'Система',
     theme_light: 'Світло',
     theme_dark: 'Темно',
+    new_group: 'Нова група',
+    default_group: 'Група за замовчуванням',
+    save_group_success: 'Групу успішно збережено',
+    delete_group_confirm: 'Підтвердити видалення цієї групи?',
+    delete_group_success: 'Групу успішно видалено',
+    warning: 'Попередження',
+    confirm: 'Підтвердити',
+    cancel: 'Скасувати',
+    filter_connections: 'Пошук підключень'
   },
 };
 

--- a/src/i18n/langs/vi.js
+++ b/src/i18n/langs/vi.js
@@ -173,6 +173,15 @@ const vi = {
     theme_system: 'Hệ thống',
     theme_light: 'Sáng',
     theme_dark: 'Tối',
+    new_group: 'Nhóm mới',
+    default_group: 'Nhóm mặc định',
+    save_group_success: 'Lưu nhóm thành công',
+    delete_group_confirm: 'Xác nhận xóa nhóm này?',
+    delete_group_success: 'Xóa nhóm thành công',
+    warning: 'Cảnh báo',
+    confirm: 'Xác nhận',
+    cancel: 'Hủy',
+    filter_connections: 'Tìm kiếm kết nối'
   },
 };
 

--- a/src/storage.js
+++ b/src/storage.js
@@ -190,4 +190,59 @@ export default {
 
     willRemovedKeys.forEach(k => localStorage.removeItem(k));
   },
+  getGroups() {
+    let groups = localStorage.groups || '[]';
+    groups = JSON.parse(groups);
+
+    // 处理旧数据，为没有 id 的分组分配 id
+    let hasChanges = false;
+    let maxId = 1; // 默认分组 id 为 1
+
+    // 先找出最大 id
+    groups.forEach(group => {
+      if (group.id && group.id > maxId) {
+        maxId = group.id;
+      }
+    });
+
+    // 为没有 id 的分组分配 id
+    groups.forEach(group => {
+      if (!group.id) {
+        maxId++;
+        group.id = maxId;
+        hasChanges = true;
+      }
+    });
+
+    // 如果有变化，保存更新后的分组
+    if (hasChanges) {
+      this.setGroups(groups);
+    }
+
+    return groups;
+  },
+  setGroups(groups) {
+    localStorage.groups = JSON.stringify(groups);
+  },
+  addGroup(group) {
+    const groups = this.getGroups();
+    // 确保新分组有 id 和 name
+    if (!group.id || !group.name) {
+      return;
+    }
+    // 检查 id 是否已存在
+    if (groups.some(g => g.id == group.id)) {
+      return;
+    }
+    groups.push(group);
+    this.setGroups(groups);
+  },
+  deleteGroup(groupId) {
+    const groups = this.getGroups();
+    const index = groups.findIndex(g => g.id == groupId);
+    if (index > -1) {
+      groups.splice(index, 1);
+      this.setGroups(groups);
+    }
+  },
 };


### PR DESCRIPTION
由于工作需要，需要管理大量项目和连接，没有分组时有点乱，增加了连接的分组功能，可以拖动分组和连接来改变顺序，适当减小了连接的高度，以便显示更多的连接。
PS: 网页前端不是我擅长的领域，相关代码由AI辅助完成，期待有缘人继续完善。

![20250529165412](https://github.com/user-attachments/assets/bb313cbf-63b6-49d2-8790-dec93c7c2be2)
