### PR TITLE
fix: reset the upload list when the import dialog closes

### DIFF
--- a/src/components/Setting.vue
+++ b/src/components/Setting.vue
@@ -128,7 +128,6 @@
       width="400px"
       :title="$t('message.select_import_file')"
       :visible.sync="importConnectionVisible"
-      @close="resetUpload"
       append-to-body>
 
       <el-upload
@@ -138,6 +137,7 @@
         action=""
         :limit="1"
         :on-change="loadConnectionFile"
+        :on-exceed="replaceConnectionFile"
         drag>
         <i class="el-icon-upload"></i>
         <div class="el-upload__text">{{ $t('message.put_file_here') }}</div>
@@ -227,17 +227,12 @@ export default {
     showImportDialog() {
       this.importConnectionVisible = true;
     },
-    resetUpload() {
-      // el-upload keeps the picked file in its own list. With :limit="1" a leftover entry
-      // makes any later pick fire on-exceed instead of on-change, so the file is never read
-      // again and importing stays broken until that entry is removed by hand.
-      this.connectionFileContent = '';
-
+    replaceConnectionFile(files) {
       const upload = this.$refs.configUpload;
 
-      if (upload) {
-        upload.clearFiles();
-      }
+      upload.clearFiles();
+      // handleStart adds the file to the list and triggers on-change to read it
+      upload.handleStart(files[0]);
     },
     loadConnectionFile(file) {
       const reader = new FileReader();
@@ -247,10 +242,8 @@ export default {
       reader.readAsText(file.raw);
     },
     importConnnection() {
-      // read the content before hiding, closing the dialog resets it
-      let config = this.$util.base64Decode(this.connectionFileContent);
-
       this.importConnectionVisible = false;
+      let config = this.$util.base64Decode(this.connectionFileContent);
 
       if (!config) {
         return;

--- a/src/components/Setting.vue
+++ b/src/components/Setting.vue
@@ -128,6 +128,7 @@
       width="400px"
       :title="$t('message.select_import_file')"
       :visible.sync="importConnectionVisible"
+      @close="resetUpload"
       append-to-body>
 
       <el-upload
@@ -226,6 +227,18 @@ export default {
     showImportDialog() {
       this.importConnectionVisible = true;
     },
+    resetUpload() {
+      // el-upload keeps the picked file in its own list. With :limit="1" a leftover entry
+      // makes any later pick fire on-exceed instead of on-change, so the file is never read
+      // again and importing stays broken until that entry is removed by hand.
+      this.connectionFileContent = '';
+
+      const upload = this.$refs.configUpload;
+
+      if (upload) {
+        upload.clearFiles();
+      }
+    },
     loadConnectionFile(file) {
       const reader = new FileReader();
       reader.onload = (event) => {
@@ -234,8 +247,10 @@ export default {
       reader.readAsText(file.raw);
     },
     importConnnection() {
-      this.importConnectionVisible = false;
+      // read the content before hiding, closing the dialog resets it
       let config = this.$util.base64Decode(this.connectionFileContent);
+
+      this.importConnectionVisible = false;
 
       if (!config) {
         return;


### PR DESCRIPTION
Importing connections only works once per app launch.

The import dialog's `el-upload` has `:limit="1"` and its file list is never cleared. Once a file has been picked, any later pick fires `on-exceed` instead of `on-change`, so `loadConnectionFile` never runs and `connectionFileContent` keeps its previous value. The second import then either re-applies the previous file's content or does nothing at all.

**Repro** (current master):

1. Settings -> Import -> pick `a.ano` -> Confirm: connections are imported
2. Settings -> Import -> pick `b.ano` -> Confirm: nothing happens, the list still shows `a.ano`'s connections

Removing the leftover entry with its X button restores the behaviour, which is the workaround users have to discover on their own.

**Fix**: clear the upload list and the cached file content when the dialog closes, so every open starts from a clean state. `el-dialog`'s `close` event covers the confirm, cancel and dismiss paths alike.

The content is now read before hiding the dialog, so the reset cannot race with the read.

<details>
<summary>Test files used for the repro</summary>

`a.ano` - legacy plain connection list:

```
W3siaG9zdCI6ICIxMjcuMC4wLjEiLCAicG9ydCI6ICI2Mzc5IiwgImF1dGgiOiAiIiwgIm5hbWUiOiAibG9jYWwtbm8tYXV0aCIsICJjbHVzdGVyIjogZmFsc2V9LCB7Imhvc3QiOiAiMTI3LjAuMC4xIiwgInBvcnQiOiAiNjM4MCIsICJhdXRoIjogInRlc3RwYXNzIiwgIm5hbWUiOiAibG9jYWwtd2l0aC1hdXRoIiwgImNsdXN0ZXIiOiBmYWxzZX0sIHsiaG9zdCI6ICJyZWRpcy5leGFtcGxlLmNvbSIsICJwb3J0IjogIjYzNzkiLCAiYXV0aCI6ICIiLCAibmFtZSI6ICIiLCAiY2x1c3RlciI6IGZhbHNlfSwgeyJob3N0IjogIjE5Mi4wLjIuMTAiLCAicG9ydCI6ICI3MDAwIiwgImF1dGgiOiAiIiwgIm5hbWUiOiAiZXhhbXBsZS1jbHVzdGVyIiwgImNsdXN0ZXIiOiB0cnVlfV0=
```

`b.ano` - new `{connections, groups}` bundle:

```
eyJjb25uZWN0aW9ucyI6IFt7Imhvc3QiOiAiMTk4LjUxLjEwMC41IiwgInBvcnQiOiAiNjM3OSIsICJhdXRoIjogIiIsICJuYW1lIjogImJ1bmRsZS1jb25uLWEiLCAiY2x1c3RlciI6IGZhbHNlLCAiZ3JvdXBJZCI6ICJncnAtZGVtbyJ9LCB7Imhvc3QiOiAiMTk4LjUxLjEwMC42IiwgInBvcnQiOiAiNjM3OSIsICJhdXRoIjogIiIsICJuYW1lIjogImJ1bmRsZS1jb25uLWIiLCAiY2x1c3RlciI6IGZhbHNlLCAiZ3JvdXBJZCI6IG51bGx9XSwgImdyb3VwcyI6IFt7ImlkIjogImdycC1kZW1vIiwgIm5hbWUiOiAiRGVtbyBHcm91cCJ9XX0=
```

Both contain only RFC 5737 documentation addresses and example.com hostnames.

</details>